### PR TITLE
Gap restructure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ repositories {
 
 dependencies {
     // VSM library - abstraction API
-    compile 'ch.hevs.biovotion.vsm:vsm:5.1.3:release@aar'
+    compile 'ch.hevs.biovotion.vsm:vsm:5.2.0:release@aar'
 
     // Generic BLE library
     compile 'ch.hevs.ble.lib:hevs-ble-library:0.8.1:release@aar'

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
+        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
     }
 }
 
@@ -14,14 +14,14 @@ apply plugin: 'com.jfrog.bintray'
 apply plugin: 'com.github.dcendents.android-maven'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "26.0.1"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.2"
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 25
-        versionCode 4
-        versionName '0.3-SNAPSHOT'
+        targetSdkVersion 27
+        versionCode 5
+        versionName '0.4-SNAPSHOT'
     }
     buildTypes {
         release {
@@ -29,9 +29,9 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
 
             libraryVariants.all { variant ->
-                variant.outputs.each { output ->
+                variant.outputs.all { output ->
                     if (output.outputFile != null && output.outputFile.name.endsWith('.aar')) {
-                        output.outputFile = new File(output.outputFile.parent,
+                        outputFileName = new File(output.outputFile.parent,
                                 "${archivesBaseName}-${android.defaultConfig.versionName}.aar")
                     }
                 }
@@ -71,22 +71,27 @@ configurations.compile {
 
 repositories {
     jcenter()
+    google()
     maven { url 'https://oss.jfrog.org/artifactory/oss-snapshot-local' }
+    maven { url 'https://jitpack.io' }
     flatDir { dirs 'libs' }
 }
 
 dependencies {
     // VSM library - abstraction API
-    compile 'ch.hevs.biovotion.vsm:vsm:5.2.0:release@aar'
+    implementation 'ch.hevs.biovotion.vsm:vsm:5.2.0:release@aar'
 
     // Generic BLE library
-    compile 'ch.hevs.ble.lib:hevs-ble-library:0.8.1:release@aar'
+    implementation 'ch.hevs.ble.lib:hevs-ble-library:0.8.1:release@aar'
 
-    compile 'org.radarcns:radar-commons-android:0.3'
-    compile 'org.radarcns:radar-schemas-commons:0.2'
+    runtimeOnly 'com.squareup.okhttp:okhttp:2.5.0'
+    api 'org.radarcns:radar-commons-android:0.6'
+    implementation 'org.radarcns:radar-schemas-commons:0.2.3'
 
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.slf4j:slf4j-simple:1.7.25'
+    api 'com.android.support:support-v4:27.0.2'
+
+    testImplementation 'junit:junit:4.12'
+    testRuntimeOnly 'org.slf4j:slf4j-simple:1.7.25'
 }
 
 //---------------------------------------------------------------------------//

--- a/src/main/java/org/radarcns/biovotion/BiovotionDeviceManager.java
+++ b/src/main/java/org/radarcns/biovotion/BiovotionDeviceManager.java
@@ -213,7 +213,9 @@ public class BiovotionDeviceManager
         super.close();
     }
 
-    public void disconnect() {
+    // Called when a device is disconnected. Does some housekeeping actions.
+    // Should not be called from multiple threads at the same time!
+    public synchronized void disconnect() {
         logger.info("Biovotion VSM disconnecting.");
         this.isConnected = false;
 
@@ -317,6 +319,7 @@ public class BiovotionDeviceManager
 
     @Override
     protected synchronized void updateStatus(DeviceStatusListener.Status status) {
+        if (status == getState().getStatus()) return;
         if (status == DeviceStatusListener.Status.DISCONNECTED) disconnect();
         super.updateStatus(status);
     }

--- a/src/main/java/org/radarcns/biovotion/BiovotionDeviceManager.java
+++ b/src/main/java/org/radarcns/biovotion/BiovotionDeviceManager.java
@@ -597,7 +597,7 @@ public class BiovotionDeviceManager
             } else if (gapManager.getStatus() == 0) {
                 logger.debug("Biovotion VSM GAP request running");
                 // HACK: check if last GAP request was longer than GAP_MAX_REQUEST_MS ago, disconnect
-                logger.warn("Biovotion VSM GAP request running since: {}, now: {}, runtime: {}"
+                logger.trace("Biovotion VSM GAP request running since: {}, now: {}, runtime: {}"
                         , gapManager.getRawGap().getLastGapTime(), System.currentTimeMillis(), (System.currentTimeMillis() - gapManager.getRawGap().getLastGapTime())/1000L);
                 if (System.currentTimeMillis() - gapManager.getRawGap().getLastGapTime() > VsmConstants.GAP_MAX_REQUEST_MS) {
                     logger.error("Biovotion VSM GAP request running too long, disconnecting!");
@@ -789,7 +789,7 @@ public class BiovotionDeviceManager
                 BiovotionVsm1LedCurrent ledValue = new BiovotionVsm1LedCurrent((double) unit.timestamp, timeReceived,
                     latestLedCurrent[0], latestLedCurrent[1], latestLedCurrent[2], latestLedCurrent[3]);
 
-                if (VsmConstants.VSM_REVERSE_RAW_DATA) {
+                if (!VsmConstants.VSM_REVERSE_RAW_DATA) {
                     send(ledCurrentTopic, ledValue);
                 } else {
                     // add measurements to a stack as long as new measurements are older. if a newer measurement is added, empty the stack into ledCurrentTable and start over

--- a/src/main/java/org/radarcns/biovotion/BiovotionDeviceManager.java
+++ b/src/main/java/org/radarcns/biovotion/BiovotionDeviceManager.java
@@ -591,12 +591,12 @@ public class BiovotionDeviceManager
             } else if (gapManager.getStatus() == 0) {
                 logger.debug("Biovotion VSM GAP request running");
                 // HACK: check if last GAP request was longer than GAP_MAX_REQUEST_MS ago, disconnect
-//                logger.warn("Biovotion VSM GAP request running since: {}, now: {}, runtime: {}"
-//                        , gapManager.getRawGap().getLastGapTime(), System.currentTimeMillis(), (System.currentTimeMillis() - gapManager.getRawGap().getLastGapTime())/1000L);
-//                if (System.currentTimeMillis() - gapManager.getRawGap().getLastGapTime() > VsmConstants.GAP_MAX_REQUEST_MS) {
-//                    logger.error("Biovotion VSM GAP request running too long, disconnecting!");
-//                    vsmDevice.disconnect();
-//                }
+                logger.warn("Biovotion VSM GAP request running since: {}, now: {}, runtime: {}"
+                        , gapManager.getRawGap().getLastGapTime(), System.currentTimeMillis(), (System.currentTimeMillis() - gapManager.getRawGap().getLastGapTime())/1000L);
+                if (System.currentTimeMillis() - gapManager.getRawGap().getLastGapTime() > VsmConstants.GAP_MAX_REQUEST_MS) {
+                    logger.error("Biovotion VSM GAP request running too long, disconnecting!");
+                    vsmDevice.disconnect();
+                }
                 // abort if GAP already running
                 return;
             } else if (gapManager.getStatus() > 1) {

--- a/src/main/java/org/radarcns/biovotion/BiovotionDeviceManager.java
+++ b/src/main/java/org/radarcns/biovotion/BiovotionDeviceManager.java
@@ -474,8 +474,8 @@ public class BiovotionDeviceManager
 
         // read device_mode parameter; if currently on charger, disconnect
         if (p.id() == VsmConstants.PID_DEVICE_MODE) {
-            if (p.value()[0] == VsmConstants.MOD_ONCHARGER) {
-                logger.warn("Biovotion VSM device is currently on charger, disconnecting!");
+            if (p.value()[0] == VsmConstants.MOD_ONCHARGER && gapManager.getRawGap().getGapStreamLag() < VsmConstants.GAP_MAX_PAGES*VsmConstants.GAP_MAX_PER_PAGE_VITAL_RAW) {
+                logger.warn("Biovotion VSM device is currently on charger and not downloading missing data, disconnecting!");
                 // TODO: Maybe we can use PID_SWITCH_DEVICE_OFF here? However then it seems to not reboot automatically, so might not be able to easily reconnect afterwards...
                 final Parameter disconnect = Parameter.fromBytes(VsmConstants.PID_DISCONNECT_BLE_CONN, new byte[] {(byte) 0x00});
                 paramWriteRequest(disconnect);

--- a/src/main/java/org/radarcns/biovotion/BiovotionDeviceManager.java
+++ b/src/main/java/org/radarcns/biovotion/BiovotionDeviceManager.java
@@ -663,13 +663,13 @@ public class BiovotionDeviceManager
 
     @Override
     public void onStreamMessageReceived(@NonNull final java.nio.ByteBuffer payload) {
-        logger.debug("Biovotion VSM Message received: {}", payload);
+        logger.trace("Biovotion VSM Message received: {}", payload);
         //TODO: find out what is sent here
     }
 
     @Override
     public void onStreamValueReceived(@NonNull final StreamValue unit) {
-        logger.debug("Biovotion VSM Data received: {}", unit.type);
+        logger.trace("Biovotion VSM Data received: {}", unit.type);
         double timeReceived = System.currentTimeMillis() / 1000d;
         BiovotionDeviceStatus deviceStatus = getState();
 

--- a/src/main/java/org/radarcns/biovotion/BiovotionDeviceManager.java
+++ b/src/main/java/org/radarcns/biovotion/BiovotionDeviceManager.java
@@ -113,14 +113,7 @@ public class BiovotionDeviceManager
     private final ScheduledExecutorService executor;
 
     private ScheduledFuture<?> gapFuture;
-    private final ByteBuffer gapRequestBuffer;
-    private int gap_raw_last_cnt = -1;      // latest counter index from last GAP request
-    private int gap_raw_last_idx = -1;      // start index from last GAP request
-    private int gap_raw_since_last = 0;     // number of records streamed since last GAP request
-    private int gap_raw_to_get = 0;         // number of records requested from last GAP request
-    private int gap_raw_cnt = -1;           // current latest counter index
-    private int gap_raw_num = -1;           // current total number of records in storage
-    private int gap_stat = -1;              // current GAP status
+    private BiovotionGAPManager gapManager;
 
     private Deque<BiovotionVsm1Acceleration> gap_raw_stack_acc;
     private Deque<BiovotionVsm1PpgRaw> gap_raw_stack_ppg;
@@ -196,11 +189,12 @@ public class BiovotionDeviceManager
 
         this.executor = Executors.newSingleThreadScheduledExecutor();
 
+        this.gapManager = new BiovotionGAPManager(getService());
+
         this.gap_raw_stack_acc = new ArrayDeque<>(1024);
         this.gap_raw_stack_ppg = new ArrayDeque<>(1024);
         this.gap_raw_stack_led_current = new ArrayDeque<>(1024);
 
-        this.gapRequestBuffer = ByteBuffer.allocate(9).order(ByteOrder.LITTLE_ENDIAN);
         this.utcBuffer = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN);
 
         synchronized (this) {
@@ -361,6 +355,8 @@ public class BiovotionDeviceManager
         // check for GSR mode on
         paramReadRequest(VsmConstants.PID_GSR_ON);
 
+        gapManager.setDeviceId(getState().getId().getSourceId());
+
         updateStatus(DeviceStatusListener.Status.CONNECTED);
         this.isConnected = true;
     }
@@ -461,11 +457,15 @@ public class BiovotionDeviceManager
         logger.debug("Biovotion VSM Parameter written: {}", id);
 
         if (id == VsmConstants.PID_UTC) paramReadRequest(VsmConstants.PID_UTC);
+        else if (id == VsmConstants.PID_GAP_RECORD_REQUEST) gapManager.rawGapSuccessful();
+        // else if (id == VsmConstants.PID_GAP_RECORD_REQUEST) gapManager.getRawGap().setGapResponse(?); TODO: set GAP response, currently not implemeted by Biovotion?
     }
 
     @Override
     public void onParameterWriteError(@NonNull final ParameterController ctrl, int id, final int errorCode) {
         logger.error("Biovotion VSM Parameter write error, id={}, error={}", id, errorCode);
+
+        if (id == VsmConstants.PID_GAP_RECORD_REQUEST) gapManager.setStatus(1); // reset manual override status after GAP error
     }
 
     @Override
@@ -509,135 +509,56 @@ public class BiovotionDeviceManager
             //Boast.makeText(context, "Biovotion device UTC: " + p.valueAsInteger(), Toast.LENGTH_LONG).show();
         }
 
-        /**
-         * GAP request chain: gap status -> num data -> latest counter -> calculate gap -> gap request
-         *
-         * GAP requests will trigger streaming of data saved on the device, either raw data (which is never automatically streamed),
-         * or algo data (which was not streamed due to missing connection).
-         *
-         * A GAP request will need the following parameters:
-         * - gap_type: the type of data to be streamed
-         * - gap_start: the counter value from where to begin streaming
-         * - gap_range: the range, i.e. number of samples to be streamed
-         *
-         * Data is saved internally in a RingBuffer like structure, with two public values as an interface:
-         * - number of data in the buffer (NUMBER_OF_[]_SETS_IN_STORAGE)
-         * - latest counter value (LAST_[]_COUNTER_VALUE)
-         * The first will max out once the storage limit is reached, and new values will overwrite old ones in a FIFO behaviour.
-         * The second will keep incrementing when new samples are recorded into storage. (4 Byte unsigned int, overflow after ~2.66 years @ 51.2 Hz)
-         *
-         * The newest data sample has the id (counter value) LAST_[]_COUNTER_VALUE, the oldest has the id 0
-         * A GAP request will accordingly stream 'backwards' w.r.t. sample id's and time:
-         * Suppose gap_start = 999 and gap_range = 1000, the oldest 1000 samples will be streamed, in reverse-chronological order. (caveat see below 'pages')
-         *
-         * In the case of this application, the most recent raw data is requested at a fixed rate, in the following fashion:
-         * - the current GAP status is queried, if a GAP request is running (=0) the new request is aborted
-         * - the number of records and latest counter value are queried
-         * - the new starting index is the latest counter value
-         * - the range of values to request is calculated via the difference of the current latest counter and the latest counter at time of the last GAP request
-         * - a new GAP request is issued with the calculated values, and the current latest counter value is saved
-         *
-         * Pages:
-         * The data on the device is stored in pages of a specific number of samples (e.g. 17 in case of raw data). When getting data via GAP request,
-         * data will always be streamed in whole pages, i.e. if the start or end point of a GAP request is in the middle of a page, that whole page will
-         * still be streamed. This may result in more data being streamed than was requested.
-         *
+
+        /*
+         * RAW GAP REQUEST
          */
 
         // read GAP request status
         else if (p.id() == VsmConstants.PID_GAP_REQUEST_STATUS) {
-            gap_stat = p.value()[0];
-            if (gap_stat == 0) {
+            gapManager.setStatus(p.value()[0]);
+
+            logger.debug("Biovotion VSM GAP status: {}", gapManager);
+
+            // abort if GAP already running
+            if (gapManager.getStatus() == 0) {
                 logger.debug("Biovotion VSM GAP request running");
                 return;
             }
             // TODO: handle GAP error statuses (gap_stat > 1)
-
-            logger.debug("Biovotion VSM GAP status: raw_cnt:{} | raw_num:{} | gap_stat:{}", gap_raw_cnt, gap_raw_num, gap_stat);
 
             paramReadRequest(VsmConstants.PID_NUMBER_OF_RAW_DATA_SETS_IN_STORAGE);
         }
 
         // read number of raw data sets currently in device storage
         else if (p.id() == VsmConstants.PID_NUMBER_OF_RAW_DATA_SETS_IN_STORAGE) {
-            gap_raw_num = p.valueAsInteger();
-            logger.debug("Biovotion VSM GAP status: raw_cnt:{} | raw_num:{} | gap_stat:{}", gap_raw_cnt, gap_raw_num, gap_stat);
+            gapManager.getRawGap().setGapNum(p.valueAsInteger());
+
+            logger.debug("Biovotion VSM GAP status: {}", gapManager);
 
             paramReadRequest(VsmConstants.PID_LAST_RAW_COUNTER_VALUE);
         }
 
         // read current latest record counter id. may initiate GAP request here
         else if (p.id() == VsmConstants.PID_LAST_RAW_COUNTER_VALUE) {
-            gap_raw_cnt = p.valueAsInteger();
-            if (gap_raw_last_cnt < 0) gap_raw_last_cnt = gap_raw_cnt; // init
+            gapManager.getRawGap().setGapCount(p.valueAsInteger());
 
-            int new_idx = gap_raw_cnt;
-
-            // set the number of records to request at this point
-            //int records_to_get = VsmConstants.GAP_NUM_PAGES * VsmConstants.GAP_MAX_PER_PAGE_VITAL_RAW;
-            int records_to_get = gap_raw_cnt - gap_raw_last_cnt;
-
-            logger.debug("Biovotion VSM GAP status: raw_cnt:{}:{} | raw_toget:{}:{} | gap_stat:{}", gap_raw_cnt, gap_raw_last_cnt, records_to_get, gap_raw_to_get, gap_stat);
+            logger.debug("Biovotion VSM GAP status: {}", gapManager);
 
             // GAP request here
-            if (gap_stat != 0 && gap_raw_cnt > 0 && gap_raw_num > 0
-                    && records_to_get > 0
-                    && (gap_raw_num - records_to_get) > 0 // cant request more records than are stored on the device
-                    && (new_idx+1) % VsmConstants.GAP_MAX_PER_PAGE_VITAL_RAW == 0 // dont make a request if the index is not a multiple of the page size, to avoid getting more records than were requested
-                    && records_to_get % VsmConstants.GAP_MAX_PER_PAGE_VITAL_RAW == 0) // dont make a request if the number of records to get is not a multiple of the page size, to avoid getting more records than were requested
-            {
-                if (gap_raw_since_last != gap_raw_to_get)
-                    logger.warn("Biovotion VSM GAP num samples since last request ({}) is not equal with num records to get ({})!", gap_raw_since_last, gap_raw_to_get);
-
-                if (!gapRequest(VsmConstants.GAP_TYPE_VITAL_RAW, new_idx, records_to_get)) {
-                    logger.error("Biovotion VSM GAP request failed!");
-                } else {
-                    gap_raw_since_last = 0;
-                    gap_raw_last_idx = new_idx;
-                    gap_raw_last_cnt = gap_raw_cnt;
-                    gap_raw_to_get = records_to_get;
-                    paramReadRequest(VsmConstants.PID_GAP_REQUEST_STATUS);
-                }
-            }
-            else if (gap_stat != 0 && gap_raw_cnt > 0 && gap_raw_num > 0
-                    && records_to_get > 0
-                    && (gap_raw_num - records_to_get) > 0
-                    && ((new_idx+1) % VsmConstants.GAP_MAX_PER_PAGE_VITAL_RAW != 0 || records_to_get % VsmConstants.GAP_MAX_PER_PAGE_VITAL_RAW != 0))
-            {
-                paramReadRequest(VsmConstants.PID_LAST_RAW_COUNTER_VALUE); // immediately try again if aborted due to page size checks
+            Parameter rawGapReq = gapManager.newRawGap();
+            gapManager.getRawGap().setLastGapRequest(rawGapReq);
+            if (rawGapReq != null && !paramWriteRequest(rawGapReq)) {
+                logger.error("Biovotion VSM GAP raw request failed!");
+            } else {
+                logger.debug("Biovotion VSM GAP raw request skipped");
             }
         }
-
     }
 
     @Override
     public void onParameterReadError(@NonNull final ParameterController ctrl, int id) {
         logger.error("Biovotion VSM Parameter read error, id={}", id);
-    }
-
-
-    /**
-     * make a new GAP request
-     * @param gap_type data type of GAP request
-     * @param gap_start counter value from where to begin (backwards, e.g. last counter)
-     * @param gap_range number of records to get
-     * @return write request success
-     */
-    public boolean gapRequest(int gap_type, int gap_start, int gap_range) {
-        if (gap_start <= 0 || gap_range <= 0 || gap_range > gap_start+1) return false;
-
-        // build the complete request value byte array
-        byte[] ba_gap_req_value = gapRequestBuffer
-                .put((byte) gap_type)
-                .putInt(gap_start)
-                .putInt(gap_range)
-                .array();
-        gapRequestBuffer.clear();
-
-        // send the request
-        logger.debug("Biovotion VSM GAP new request: type:{} start:{} range:{}", gap_type, gap_start, gap_range);
-        final Parameter gap_req = Parameter.fromBytes(VsmConstants.PID_GAP_RECORD_REQUEST, ba_gap_req_value);
-        return paramWriteRequest(gap_req);
     }
 
 
@@ -762,7 +683,7 @@ public class BiovotionDeviceManager
                     gap_raw_stack_acc.addFirst(accValue);
                     gap_raw_stack_ppg.addFirst(ppgValue);
 
-                    gap_raw_since_last++;
+                    gapManager.getRawGap().incGapSinceLast();
                 }
                 break;
 

--- a/src/main/java/org/radarcns/biovotion/BiovotionDeviceManager.java
+++ b/src/main/java/org/radarcns/biovotion/BiovotionDeviceManager.java
@@ -404,6 +404,7 @@ public class BiovotionDeviceManager
         logger.info("Biovotion VSM device {} connected.", device.descriptor().name());
 
         vsmScanner.stopScanning();
+        vsmScanner = null;
         vsmDevice = device;
 
         vsmStreamController = vsmDevice.streamController();
@@ -416,6 +417,14 @@ public class BiovotionDeviceManager
         final Parameter time = Parameter.fromBytes(VsmConstants.PID_UTC, time_bytes);
         paramWriteRequest(time);
         utcBuffer.clear();
+
+        // read device info
+        paramReadRequest(VsmConstants.PID_FIRMWARE_M4_VERSION);
+        paramReadRequest(VsmConstants.PID_FIRMWARE_AS7000_VERSION);
+        paramReadRequest(VsmConstants.PID_HW_VERSION);
+        paramReadRequest(VsmConstants.PID_FIRMWARE_BLE_VERSION);
+        paramReadRequest(VsmConstants.PID_INTERFACE_VERSION);
+        paramReadRequest(VsmConstants.PID_UNIQUE_DEVICE_ID);
 
         // check for device state
         paramReadRequest(VsmConstants.PID_DEVICE_MODE);
@@ -559,6 +568,17 @@ public class BiovotionDeviceManager
             if (p.value()[0] == VsmConstants.MOD_ONCHARGER
                     && gapManager.getRawGap().getGapStreamLag() >= 0
                     && gapManager.getRawGap().getGapStreamLag() < VsmConstants.GAP_MAX_PAGES*VsmConstants.GAP_MAX_PER_PAGE_VITAL_RAW) {
+                // If GAPs not initialized, check again in 1 second.
+                if (gapManager.getRawGap().getGapCount() < 0) {
+                    executor.schedule(
+                            new Runnable() {
+                                @Override
+                                public void run() {
+                                    paramReadRequest(VsmConstants.PID_DEVICE_MODE);
+                                }
+                            }, 1000L, TimeUnit.MILLISECONDS);
+                    return;
+                }
                 logger.warn("Biovotion VSM device is currently on charger and not uploading local data, disconnecting!");
                 logger.warn("Biovotion VSM GAP status: {}", gapManager);
 
@@ -650,6 +670,33 @@ public class BiovotionDeviceManager
                 logger.debug("Biovotion VSM GAP raw request created was null, skipping.");
             }
         }
+
+
+        // read device and version info, other parameters
+        else {
+            switch (p.id()) {
+                case VsmConstants.PID_INTERFACE_VERSION:
+                    logger.info("PID_INTERFACE_VERSION: {}", p.valueAsString());
+                    break;
+                case VsmConstants.PID_FIRMWARE_M4_VERSION:
+                    logger.info("PID_FIRMWARE_M4_VERSION: {}", p.valueAsString());
+                    break;
+                case VsmConstants.PID_FIRMWARE_AS7000_VERSION:
+                    logger.info("PID_FIRMWARE_AS7000_VERSION: {}", p.valueAsString());
+                    break;
+                case VsmConstants.PID_HW_VERSION:
+                    logger.info("PID_HW_VERSION: {}", p.valueAsString());
+                    break;
+                case VsmConstants.PID_FIRMWARE_BLE_VERSION:
+                    logger.info("PID_FIRMWARE_BLE_VERSION: {}", p.valueAsString());
+                    break;
+                case VsmConstants.PID_UNIQUE_DEVICE_ID:
+                    logger.info("PID_UNIQUE_DEVICE_ID: {}", p.valueAsString());
+                    break;
+                default:
+                    logger.info("{}", p);
+            }
+        }
     }
 
     @Override
@@ -659,11 +706,13 @@ public class BiovotionDeviceManager
 
 
     public boolean paramReadRequest(int id) {
+        logger.trace("Biovotion VSM parameter read request. id:{}", id);
         boolean success = vsmParameterController.readRequest(id);
         if (!success) logger.error("Biovotion VSM parameter read request error. id:{}", id);
         return success;
     }
     public boolean paramWriteRequest(Parameter param) {
+        logger.trace("Biovotion VSM parameter write request. parameter:{}", param);
         boolean success = vsmParameterController.writeRequest(param);
         if (!success) logger.error("Biovotion VSM parameter write request error. parameter:{}", param);
         return success;

--- a/src/main/java/org/radarcns/biovotion/BiovotionGAPManager.java
+++ b/src/main/java/org/radarcns/biovotion/BiovotionGAPManager.java
@@ -139,6 +139,11 @@ public class BiovotionGAPManager {
             int start_ix = getRawGap().nextIndex();
             int records_to_get = getRawGap().recordsToGet();
 
+            if (records_to_get == 0 && getRawGap().getGapCount() != getRawGap().getGapLastIndex()) {
+                getRawGap().setGapLastIndex(getRawGap().getGapCount());
+                logger.warn("Biovotion VSM GAP lastIndex reset to maximum index {}, due to records_to_get abnormal 0", getRawGap().getGapCount());
+            }
+
             return buildGapRequest(VsmConstants.GAP_TYPE_VITAL_RAW, start_ix, records_to_get);
         } else if (getRawGap().requestViableCheck() && !getRawGap().pageSizeCheck()) {
             logger.warn("Biovotion VSM GAP pageSizeCheck:{} nextIndex():{} recordsToGet:{}", getRawGap().pageSizeCheck(), getRawGap().nextIndex(), getRawGap().recordsToGet());

--- a/src/main/java/org/radarcns/biovotion/BiovotionGAPManager.java
+++ b/src/main/java/org/radarcns/biovotion/BiovotionGAPManager.java
@@ -149,6 +149,7 @@ public class BiovotionGAPManager {
     public void rawGapSuccessful() {
         getRawGap().setGapLastGet(getRawGap().recordsToGet());
         getRawGap().setGapLastIndex(getRawGap().nextIndex());
+        //getRawGap().setGapLastIndex(getRawGap().getGapCount()); // DEBUG: reset gapLastIndex
     }
 
 

--- a/src/main/java/org/radarcns/biovotion/BiovotionGAPManager.java
+++ b/src/main/java/org/radarcns/biovotion/BiovotionGAPManager.java
@@ -124,7 +124,7 @@ public class BiovotionGAPManager {
         gapRequestBuffer.clear();
 
         // send the request
-        logger.debug("Biovotion VSM GAP new request: type:{} start:{} range:{}", gap_type, gap_start, gap_range);
+        logger.info("Biovotion VSM GAP new request: type:{} start:{} range:{}", gap_type, gap_start, gap_range);
         return Parameter.fromBytes(VsmConstants.PID_GAP_RECORD_REQUEST, ba_gap_req_value);
     }
 

--- a/src/main/java/org/radarcns/biovotion/BiovotionGAPManager.java
+++ b/src/main/java/org/radarcns/biovotion/BiovotionGAPManager.java
@@ -125,7 +125,7 @@ public class BiovotionGAPManager {
                 .array();
         gapRequestBuffer.clear();
 
-        setFirstRawRequest(false);
+        if (isFirstRawRequest()) setFirstRawRequest(false);
 
         // send the request
         logger.info("Biovotion VSM GAP new request: type:{} start:{} range:{}", gap_type, gap_start, gap_range);

--- a/src/main/java/org/radarcns/biovotion/BiovotionGAPManager.java
+++ b/src/main/java/org/radarcns/biovotion/BiovotionGAPManager.java
@@ -33,6 +33,7 @@ public class BiovotionGAPManager {
 
     private String deviceId;
     private int gapStatus;
+    private boolean firstRawRequest;
     private final ByteBuffer gapRequestBuffer;
     private BiovotionGAPState rawGap;
 
@@ -75,6 +76,7 @@ public class BiovotionGAPManager {
     public BiovotionGAPManager(Context context) {
         this.gapRequestBuffer = ByteBuffer.allocate(9).order(ByteOrder.LITTLE_ENDIAN);
         this.gapStatus = -1;
+        this.firstRawRequest = true;
         this.rawGap = new BiovotionGAPState(context);
         this.deviceId = null;
     }
@@ -123,6 +125,8 @@ public class BiovotionGAPManager {
                 .array();
         gapRequestBuffer.clear();
 
+        setFirstRawRequest(false);
+
         // send the request
         logger.info("Biovotion VSM GAP new request: type:{} start:{} range:{}", gap_type, gap_start, gap_range);
         return Parameter.fromBytes(VsmConstants.PID_GAP_RECORD_REQUEST, ba_gap_req_value);
@@ -162,5 +166,13 @@ public class BiovotionGAPManager {
     @Override
     public String toString() {
         return String.format(Locale.getDefault(), "Status: %d\nRAW: %s", getStatus(), getRawGap());
+    }
+
+    public boolean isFirstRawRequest() {
+        return firstRawRequest;
+    }
+
+    public void setFirstRawRequest(boolean firstRawRequest) {
+        this.firstRawRequest = firstRawRequest;
     }
 }

--- a/src/main/java/org/radarcns/biovotion/BiovotionGAPManager.java
+++ b/src/main/java/org/radarcns/biovotion/BiovotionGAPManager.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2017 Uniklinik Freiburg and The Hyve
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.radarcns.biovotion;
+
+import android.content.Context;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Locale;
+
+import ch.hevs.biovotion.vsm.parameters.Parameter;
+
+/** Manages GAP status and requests for a Biovotion VSM wearable, for raw data streaming */
+public class BiovotionGAPManager {
+    private static final Logger logger = LoggerFactory.getLogger(BiovotionGAPManager.class);
+
+    private String deviceId;
+    private int gapStatus;
+    private final ByteBuffer gapRequestBuffer;
+    private BiovotionGAPState rawGap;
+
+
+    /**
+     * GAP request chain: gap status -> num data -> latest counter -> calculate gap -> gap request
+     *
+     * GAP requests will trigger streaming of data saved on the device, either raw data (which is never automatically streamed),
+     * or algo data (which was not streamed due to missing connection).
+     *
+     * A GAP request will need the following parameters:
+     * - gap_type: the type of data to be streamed
+     * - gap_start: the counter value from where to begin streaming
+     * - gap_range: the range, i.e. number of samples to be streamed
+     *
+     * Data is saved internally in a RingBuffer like structure, with two public values as an interface:
+     * - number of data in the buffer (NUMBER_OF_[]_SETS_IN_STORAGE)
+     * - latest counter value (LAST_[]_COUNTER_VALUE)
+     * The first will max out once the storage limit is reached, and new values will overwrite old ones in a FIFO behaviour.
+     * The second will keep incrementing when new samples are recorded into storage. (4 Byte unsigned int, overflow after ~2.66 years @ 51.2 Hz)
+     *
+     * The newest data sample has the id (counter value) LAST_[]_COUNTER_VALUE, the oldest has the id 0
+     * A GAP request will accordingly stream 'backwards' w.r.t. sample id's and time:
+     * Suppose gap_start = 999 and gap_range = 1000, the oldest 1000 samples will be streamed, in reverse-chronological order. (caveat see below 'pages')
+     *
+     * In the case of this application, the most recent raw data is requested at a fixed rate, in the following fashion:
+     * - the current GAP status is queried, if a GAP request is running (=0) the new request is aborted
+     * - the number of records and latest counter value are queried
+     * - the new starting index is the latest counter value
+     * - the range of values to request is calculated via the difference of the current latest counter and the latest counter at time of the last GAP request
+     * - a new GAP request is issued with the calculated values, and the current latest counter value is saved
+     *
+     * Pages:
+     * The data on the device is stored in pages of a specific number of samples (e.g. 17 in case of raw data). When getting data via GAP request,
+     * data will always be streamed in whole pages, i.e. if the start or end point of a GAP request is in the middle of a page, that whole page will
+     * still be streamed. This may result in more data being streamed than was requested.
+     *
+     */
+
+    public BiovotionGAPManager(Context context) {
+        this.gapRequestBuffer = ByteBuffer.allocate(9).order(ByteOrder.LITTLE_ENDIAN);
+        this.gapStatus = -1;
+        this.rawGap = new BiovotionGAPState(context);
+        this.deviceId = null;
+    }
+
+
+    public int getStatus() {
+        return this.gapStatus;
+    }
+    public void setStatus(int status) {
+        this.gapStatus = status;
+        this.rawGap.setGapStatus(status);
+    }
+
+    public BiovotionGAPState getRawGap() {
+        return rawGap;
+    }
+    public void setRawGap(BiovotionGAPState raw_gap) {
+        this.rawGap = raw_gap;
+    }
+
+    public String getDeviceId() {
+        return deviceId;
+    }
+
+    public void setDeviceId(String deviceId) {
+        this.deviceId = deviceId;
+        this.getRawGap().setDeviceId(deviceId);
+    }
+
+
+    /**
+     * make a new GAP request
+     * @param gap_type data type of GAP request
+     * @param gap_start counter value from where to begin (backwards, e.g. last counter)
+     * @param gap_range number of records to get
+     * @return Parameter with gap request info
+     */
+    public Parameter buildGapRequest(int gap_type, int gap_start, int gap_range) {
+        if (gap_start <= 0 || gap_range <= 0 || gap_range > gap_start+1) return null;
+
+        // build the complete request value byte array
+        byte[] ba_gap_req_value = gapRequestBuffer
+                .put((byte) gap_type)
+                .putInt(gap_start)
+                .putInt(gap_range)
+                .array();
+        gapRequestBuffer.clear();
+
+        // send the request
+        logger.debug("Biovotion VSM GAP new request: type:{} start:{} range:{}", gap_type, gap_start, gap_range);
+        return Parameter.fromBytes(VsmConstants.PID_GAP_RECORD_REQUEST, ba_gap_req_value);
+    }
+
+    public Parameter newRawGap() {
+        if (getRawGap().requestViableCheck() && getRawGap().pageSizeCheck()) {
+            if (getRawGap().getGapSinceLast() != getRawGap().getGapLastGet())
+                logger.warn("Biovotion VSM GAP num samples since last request ({}) is not equal with num records to get ({})!", getRawGap().getGapSinceLast(), getRawGap().getGapLastGet());
+            getRawGap().setGapSinceLast(0);
+            setStatus(0); // manually override status to prevent immediate second GAP request
+
+            int start_ix = getRawGap().nextIndex();
+            int records_to_get = getRawGap().recordsToGet();
+
+            return buildGapRequest(VsmConstants.GAP_TYPE_VITAL_RAW, start_ix, records_to_get);
+        } else if (getRawGap().requestViableCheck() && !getRawGap().pageSizeCheck()) {
+            logger.warn("Biovotion VSM GAP pageSizeCheck:{} nextIndex():{} recordsToGet:{}", getRawGap().pageSizeCheck(), getRawGap().nextIndex(), getRawGap().recordsToGet());
+        }
+
+        return null;
+    }
+
+    public void rawGapSuccessful() {
+        getRawGap().setGapLastGet(getRawGap().recordsToGet());
+        getRawGap().setGapLastIndex(getRawGap().nextIndex());
+    }
+
+
+    @Override
+    public String toString() {
+        return String.format(Locale.getDefault(), "Status: %d\nRAW: %s", getStatus(), getRawGap());
+    }
+}

--- a/src/main/java/org/radarcns/biovotion/BiovotionGAPManager.java
+++ b/src/main/java/org/radarcns/biovotion/BiovotionGAPManager.java
@@ -130,10 +130,11 @@ public class BiovotionGAPManager {
 
     public Parameter newRawGap() {
         if (getRawGap().requestViableCheck() && getRawGap().pageSizeCheck()) {
-            if (getRawGap().getGapSinceLast() != getRawGap().getGapLastGet())
-                logger.warn("Biovotion VSM GAP num samples since last request ({}) is not equal with num records to get ({})!", getRawGap().getGapSinceLast(), getRawGap().getGapLastGet());
+            // TODO: FIXME: sometimes the device seems to send a lot more data than was requested in the last GAP (-> SinceLast > LastRange), need to find out the cause (maybe firmware issue?) (-> duplicate data? unnecessary lag?)
+            if (getRawGap().getGapSinceLast() != getRawGap().getGapLastRange())
+                logger.warn("Biovotion VSM GAP num samples since last request ({}) is not equal with num records to get ({})!", getRawGap().getGapSinceLast(), getRawGap().getGapLastRange());
             getRawGap().setGapSinceLast(0);
-            setStatus(0); // manually override status to prevent immediate second GAP request
+            setStatus(0); // manually override status to prevent immediate second GAP request TODO: do this properly somehow
 
             int start_ix = getRawGap().nextIndex();
             int records_to_get = getRawGap().recordsToGet();
@@ -147,7 +148,7 @@ public class BiovotionGAPManager {
     }
 
     public void rawGapSuccessful() {
-        getRawGap().setGapLastGet(getRawGap().recordsToGet());
+        getRawGap().setGapLastRange(getRawGap().recordsToGet());
         getRawGap().setGapLastIndex(getRawGap().nextIndex());
         //getRawGap().setGapLastIndex(getRawGap().getGapCount()); // DEBUG: reset gapLastIndex
     }

--- a/src/main/java/org/radarcns/biovotion/BiovotionGAPState.java
+++ b/src/main/java/org/radarcns/biovotion/BiovotionGAPState.java
@@ -51,6 +51,7 @@ public class BiovotionGAPState {
         this.gapLastRange = 0;
         this.gapCount = -1;
         this.gapNum = -1;
+        this.gapStreamLag = 0;
 
         this.lastGapRequest = null;
         this.deviceId = null;
@@ -220,7 +221,7 @@ public class BiovotionGAPState {
     }
 
     public void setGapStreamLag(int gapStreamLag) {
-        this.gapStreamLag = gapStreamLag;
+        this.gapStreamLag = (gapStreamLag < 0) ? 0 : gapStreamLag;
     }
 
     public void updateGapStreamLag() {

--- a/src/main/java/org/radarcns/biovotion/BiovotionGAPState.java
+++ b/src/main/java/org/radarcns/biovotion/BiovotionGAPState.java
@@ -34,7 +34,7 @@ public class BiovotionGAPState {
     private int gapCount;         // current latest counter index
     private int gapNum;           // current total number of records in storage
     private int gapLastIndex;     // start index from last GAP request
-    private int gapLastGet;       // number of records requested from last GAP request
+    private int gapLastRange;     // number of records requested from last GAP request
     private int gapSinceLast;     // number of records streamed since last GAP request
     private int gapStreamLag;     // approximate number of records the streaming lags behind the device
 
@@ -47,7 +47,7 @@ public class BiovotionGAPState {
         this.gapResponse = 0;
         this.gapLastIndex = -1;
         this.gapSinceLast = 0;
-        this.gapLastGet = 0;
+        this.gapLastRange = 0;
         this.gapCount = -1;
         this.gapNum = -1;
 
@@ -64,7 +64,7 @@ public class BiovotionGAPState {
                 ", gapCount=" + gapCount +
                 ", gapNum=" + gapNum +
                 ", gapLastIndex=" + gapLastIndex +
-                ", gapLastGet=" + gapLastGet +
+                ", gapLastRange=" + gapLastRange +
                 ", gapSinceLast=" + gapSinceLast +
                 ", gapStreamLag=" + gapStreamLag +
                 '}';
@@ -92,7 +92,7 @@ public class BiovotionGAPState {
     }
 
     public void clearPrefs() {
-        SharedPreferences prefs = this.context.getSharedPreferences(VsmConstants.BIOVOTION_PREFS, Context.MODE_PRIVATE);
+        SharedPreferences prefs = this.context.getSharedPreferences(VsmConstants.VSM_PREFS, Context.MODE_PRIVATE);
         prefs.edit().clear().apply();
     }
 
@@ -142,8 +142,8 @@ public class BiovotionGAPState {
 
     public int getGapLastIndex() {
         if (getDeviceId() != null && gapLastIndex < 0) {
-            SharedPreferences prefs = this.context.getSharedPreferences(VsmConstants.BIOVOTION_PREFS, Context.MODE_PRIVATE);
-            gapLastIndex = prefs.getInt(VsmConstants.GAP_LAST_INDEX+"_"+getDeviceId(), getGapCount());
+            SharedPreferences prefs = this.context.getSharedPreferences(VsmConstants.VSM_PREFS, Context.MODE_PRIVATE);
+            gapLastIndex = prefs.getInt(VsmConstants.VSM_PREFS_GAP_LAST_INDEX+"_"+getDeviceId(), getGapCount());
         }
         if (VsmConstants.GAP_MAX_LOOKBACK_MS > 0 && getGapCount() - gapLastIndex > samples_from_ms(VsmConstants.GAP_MAX_LOOKBACK_MS))
             gapLastIndex = getGapCount() - samples_from_ms(VsmConstants.GAP_MAX_LOOKBACK_MS);
@@ -152,18 +152,18 @@ public class BiovotionGAPState {
 
     public void setGapLastIndex(int gapLastIndex) {
         if (getDeviceId() != null) {
-            SharedPreferences prefs = this.context.getSharedPreferences(VsmConstants.BIOVOTION_PREFS, Context.MODE_PRIVATE);
-            prefs.edit().putInt(VsmConstants.GAP_LAST_INDEX+"_"+getDeviceId(), gapLastIndex).apply();
+            SharedPreferences prefs = this.context.getSharedPreferences(VsmConstants.VSM_PREFS, Context.MODE_PRIVATE);
+            prefs.edit().putInt(VsmConstants.VSM_PREFS_GAP_LAST_INDEX+"_"+getDeviceId(), gapLastIndex).apply();
         }
         this.gapLastIndex = gapLastIndex;
     }
 
-    public int getGapLastGet() {
-        return gapLastGet;
+    public int getGapLastRange() {
+        return gapLastRange;
     }
 
-    public void setGapLastGet(int gapLastGet) {
-        this.gapLastGet = gapLastGet;
+    public void setGapLastRange(int gapLastRange) {
+        this.gapLastRange = gapLastRange;
     }
 
     public int getGapSinceLast() {

--- a/src/main/java/org/radarcns/biovotion/BiovotionGAPState.java
+++ b/src/main/java/org/radarcns/biovotion/BiovotionGAPState.java
@@ -164,6 +164,8 @@ public class BiovotionGAPState {
     }
 
     public void setGapLastIndex(int gapLastIndex) {
+        logger.debug("Biovotion VSM GAP lastIndex setting to {}", gapLastIndex);
+
         // reset to max lookback if exceeded
         if (VsmConstants.GAP_MAX_LOOKBACK_MS > 0 && getGapCount() - gapLastIndex > samples_from_ms(VsmConstants.GAP_MAX_LOOKBACK_MS)) {
             gapLastIndex = getGapCount() - samples_from_ms(VsmConstants.GAP_MAX_LOOKBACK_MS);
@@ -177,7 +179,7 @@ public class BiovotionGAPState {
         }
 
         // reset to current GAP count if exceeded
-        if (gapLastIndex > maximumIndex()) {
+        if (maximumIndex() > -1 && gapLastIndex > maximumIndex()) {
             gapLastIndex = maximumIndex();
             logger.warn("Biovotion VSM GAP lastIndex reset to {}, due to maximum index ({}) exceeded", gapLastIndex, maximumIndex());
         }

--- a/src/main/java/org/radarcns/biovotion/BiovotionGAPState.java
+++ b/src/main/java/org/radarcns/biovotion/BiovotionGAPState.java
@@ -143,9 +143,9 @@ public class BiovotionGAPState {
     public int getGapLastIndex() {
         if (getDeviceId() != null && gapLastIndex < 0) {
             SharedPreferences prefs = this.context.getSharedPreferences(VsmConstants.BIOVOTION_PREFS, Context.MODE_PRIVATE);
-            gapLastIndex = prefs.getInt(VsmConstants.GAP_LAST_INDEX+"_"+getDeviceId(), -1);
+            gapLastIndex = prefs.getInt(VsmConstants.GAP_LAST_INDEX+"_"+getDeviceId(), getGapCount());
         }
-        if (getGapCount() - gapLastIndex > samples_from_ms(VsmConstants.GAP_MAX_LOOKBACK_MS))
+        if (VsmConstants.GAP_MAX_LOOKBACK_MS > 0 && getGapCount() - gapLastIndex > samples_from_ms(VsmConstants.GAP_MAX_LOOKBACK_MS))
             gapLastIndex = getGapCount() - samples_from_ms(VsmConstants.GAP_MAX_LOOKBACK_MS);
         return gapLastIndex;
     }

--- a/src/main/java/org/radarcns/biovotion/BiovotionGAPState.java
+++ b/src/main/java/org/radarcns/biovotion/BiovotionGAPState.java
@@ -179,6 +179,7 @@ public class BiovotionGAPState {
     }
 
     public int getGapStreamLag() {
+        updateGapStreamLag();
         return gapStreamLag;
     }
 

--- a/src/main/java/org/radarcns/biovotion/BiovotionGAPState.java
+++ b/src/main/java/org/radarcns/biovotion/BiovotionGAPState.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2017 Uniklinik Freiburg and The Hyve
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.radarcns.biovotion;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ch.hevs.biovotion.vsm.parameters.Parameter;
+
+/** Manages the state of a GAP request lifetime */
+public class BiovotionGAPState {
+    private static final Logger logger = LoggerFactory.getLogger(BiovotionGAPState.class);
+
+    private int gapStatus;        // current GAP status
+    private int gapResponse;      // last GAP request response
+
+    private int gapCount;         // current latest counter index
+    private int gapNum;           // current total number of records in storage
+    private int gapLastIndex;     // start index from last GAP request
+    private int gapLastGet;       // number of records requested from last GAP request
+    private int gapSinceLast;     // number of records streamed since last GAP request
+    private int gapStreamLag;     // approximate number of records the streaming lags behind the device
+
+    private Parameter lastGapRequest; // parameter set of last sent GAP request
+
+    private String deviceId;
+
+    private Context context;
+
+    public BiovotionGAPState(Context context) {
+        this.gapStatus = -1;
+        this.gapResponse = 0;
+        this.gapLastIndex = -1;
+        this.gapSinceLast = 0;
+        this.gapLastGet = 0;
+        this.gapCount = -1;
+        this.gapNum = -1;
+
+        this.deviceId = null;
+        this.context = context;
+    }
+
+    @Override
+    public String toString() {
+        return "BiovotionGAPState{" +
+                "gapStatus=" + gapStatus +
+                ", gapResponse=" + gapResponse +
+                ", gapCount=" + gapCount +
+                ", gapNum=" + gapNum +
+                ", gapLastIndex=" + gapLastIndex +
+                ", gapLastGet=" + gapLastGet +
+                ", gapSinceLast=" + gapSinceLast +
+                ", gapStreamLag=" + gapStreamLag +
+                '}';
+    }
+
+    public boolean pageSizeCheck() {
+        boolean index_multiple = (nextIndex()+1) % VsmConstants.GAP_MAX_PER_PAGE_VITAL_RAW == 0;    // dont make a request if the index is not a multiple of the page size, to avoid getting more records than were requested
+        boolean toget_multiple = recordsToGet() % VsmConstants.GAP_MAX_PER_PAGE_VITAL_RAW == 0;     // dont make a request if the number of records to get is not a multiple of the page size, to avoid getting more records than were requested
+        return index_multiple && toget_multiple;
+    }
+    public boolean requestViableCheck() {
+        return getGapStatus() != 0 && getGapCount() > 0 && getGapNum() > 0 && recordsToGet() > 0
+                && (getGapNum() - recordsToGet()) > 0; // cant request more records than are stored on the device
+    }
+
+    public int nextIndex() {
+        return getGapLastIndex() + recordsToGet();
+    }
+
+    public int recordsToGet() {
+        int records_to_get = getGapCount() - getGapLastIndex();
+        if (records_to_get > VsmConstants.GAP_MAX_PAGES * VsmConstants.GAP_MAX_PER_PAGE_VITAL_RAW)
+            records_to_get = VsmConstants.GAP_MAX_PAGES * VsmConstants.GAP_MAX_PER_PAGE_VITAL_RAW;
+        return records_to_get;
+    }
+
+    public void clearPrefs() {
+        SharedPreferences prefs = this.context.getSharedPreferences(VsmConstants.BIOVOTION_PREFS, Context.MODE_PRIVATE);
+        prefs.edit().clear().apply();
+    }
+
+
+    /*
+     * Getter/Setter
+     */
+
+    public int getGapStatus() {
+        return gapStatus;
+    }
+
+    public void setGapStatus(int gapStatus) {
+        this.gapStatus = gapStatus;
+    }
+
+    public int getGapResponse() {
+        return gapResponse;
+    }
+
+    public void setGapResponse(int gapResponse) {
+        this.gapResponse = gapResponse;
+    }
+
+    public int getGapCount() {
+        return gapCount;
+    }
+
+    public void setGapCount(int gapCount) {
+        this.gapCount = gapCount;
+        updateGapStreamLag(); // update streaming lag behind device
+    }
+
+    public int getGapNum() {
+        return gapNum;
+    }
+
+    public void setGapNum(int gapNum) {
+        this.gapNum = gapNum;
+    }
+
+    public int getGapLastIndex() {
+        if (getDeviceId() != null && gapLastIndex < 0) {
+            SharedPreferences prefs = this.context.getSharedPreferences(VsmConstants.BIOVOTION_PREFS, Context.MODE_PRIVATE);
+            gapLastIndex = prefs.getInt(VsmConstants.GAP_LAST_INDEX+"_"+getDeviceId(), -1);
+        }
+        return gapLastIndex;
+    }
+
+    public void setGapLastIndex(int gapLastIndex) {
+        if (getDeviceId() != null) {
+            SharedPreferences prefs = this.context.getSharedPreferences(VsmConstants.BIOVOTION_PREFS, Context.MODE_PRIVATE);
+            prefs.edit().putInt(VsmConstants.GAP_LAST_INDEX+"_"+getDeviceId(), gapLastIndex).apply();
+        }
+        this.gapLastIndex = gapLastIndex;
+    }
+
+    public int getGapLastGet() {
+        return gapLastGet;
+    }
+
+    public void setGapLastGet(int gapLastGet) {
+        this.gapLastGet = gapLastGet;
+    }
+
+    public int getGapSinceLast() {
+        return gapSinceLast;
+    }
+
+    public void setGapSinceLast(int gapSinceLast) {
+        this.gapSinceLast = gapSinceLast;
+    }
+
+    public void incGapSinceLast() {
+        this.gapSinceLast++;
+    }
+
+    public int getGapStreamLag() {
+        return gapStreamLag;
+    }
+
+    public void setGapStreamLag(int gapStreamLag) {
+        this.gapStreamLag = gapStreamLag;
+    }
+
+    public void updateGapStreamLag() {
+        setGapStreamLag(getGapCount() - getGapLastIndex());
+    }
+
+    public Parameter getLastGapRequest() {
+        return lastGapRequest;
+    }
+
+    public void setLastGapRequest(Parameter lastGapRequest) {
+        this.lastGapRequest = lastGapRequest;
+    }
+
+    public String getDeviceId() {
+        return deviceId;
+    }
+
+    public void setDeviceId(String deviceId) {
+        this.deviceId = deviceId;
+    }
+}

--- a/src/main/java/org/radarcns/biovotion/BiovotionService.java
+++ b/src/main/java/org/radarcns/biovotion/BiovotionService.java
@@ -24,7 +24,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * A service that manages a BiovotionDeviceManager and a TableDataHandler to send store the data of a
@@ -32,6 +35,7 @@ import java.util.List;
  */
 public class BiovotionService extends DeviceService<BiovotionDeviceStatus> {
     private static final Logger logger = LoggerFactory.getLogger(BiovotionService.class);
+    private Map<String, Long> deviceBlacklist = Collections.synchronizedMap(new HashMap<String, Long>());
 
     @Override
     protected BiovotionDeviceManager createDeviceManager() {
@@ -41,5 +45,13 @@ public class BiovotionService extends DeviceService<BiovotionDeviceStatus> {
     @Override
     protected BiovotionDeviceStatus getDefaultState() {
         return new BiovotionDeviceStatus();
+    }
+
+    public Map<String, Long> getDeviceBlacklist() {
+        return deviceBlacklist;
+    }
+
+    public void setDeviceBlacklist(Map<String, Long> deviceBlacklist) {
+        this.deviceBlacklist = deviceBlacklist;
     }
 }

--- a/src/main/java/org/radarcns/biovotion/VsmConstants.java
+++ b/src/main/java/org/radarcns/biovotion/VsmConstants.java
@@ -51,7 +51,7 @@ public final class VsmConstants {
      */
     public final static int BLE_CONN_TIMEOUT_MS = 10000;
 
-    public final static int BLE_BLACKLIST_TIMEOUT_MS = 120000; // maximum time for device to remain in BLE connection blacklist
+    public final static int BLE_BLACKLIST_TIMEOUT_MS = 10000; // maximum time for device to remain in BLE connection blacklist
 
 
     /**

--- a/src/main/java/org/radarcns/biovotion/VsmConstants.java
+++ b/src/main/java/org/radarcns/biovotion/VsmConstants.java
@@ -36,6 +36,9 @@ public final class VsmConstants {
     public static final String BIOVOTION_PREFS = "org.radarcns.biovotion";
     public static final String GAP_LAST_INDEX = "org.radarcns.biovotion.gapLastIndex";
 
+    // Reverse raw data before sending to kafka, because GAP gets in reverse-chronological order
+    public static final boolean VSM_REVERSE_RAW_DATA = false;
+
     /**
      * Default Bluetooth connection timeout. If this timeout is reached, the callback
      * VsmDeviceListener#onVsmDeviceConnectionError(VsmDevice, VsmConnectionState) is called.

--- a/src/main/java/org/radarcns/biovotion/VsmConstants.java
+++ b/src/main/java/org/radarcns/biovotion/VsmConstants.java
@@ -24,129 +24,156 @@ package org.radarcns.biovotion;
  */
 public final class VsmConstants {
 
-  /**
-   * Key used to pass the DiscoveredEntity descriptor as intent argument.
-   * The descriptor of the discovered VSM device is serialized and passed between activities.
-   */
-  public final static String KEY_DESC_EXTRA = "key_extra_desc";
+    /**
+     * Key used to pass the DiscoveredEntity descriptor as intent argument.
+     * The descriptor of the discovered VSM device is serialized and passed between activities.
+     */
+    public final static String KEY_DESC_EXTRA = "key_extra_desc";
 
-  /**
-   * Default Bluetooth connection timeout. If this timeout is reached, the callback
-   * VsmDeviceListener#onVsmDeviceConnectionError(VsmDevice, VsmConnectionState) is called.
-   *
-   * <p>
-   * The default timeout on Android is 30 seconds. Using the BLE library, the maximum timeout value
-   * is fixed to 25 seconds.
-   * When connecting the first time to a VSM device, the connection time can be up to 5 seconds because the pairing
-   * process can take time and it is based on some internal delays.
-   */
-  public final static int BLE_CONN_TIMEOUT_MS = 10000;
+    /**
+     * sharedPreferences keys for storage of GAP request info
+     */
+    public static final String BIOVOTION_PREFS = "org.radarcns.biovotion";
+    public static final String GAP_LAST_INDEX = "org.radarcns.biovotion.gapLastIndex";
 
-
-  /**
-   * Parameter IDs according to VSM Bluetooth Comms Spec
-   */
-  public final static int PID_INTERFACE_VERSION                     = 0x00; // R
-  public final static int PID_UTC                                   = 0x01; // RW
-  public final static int PID_ALGO_MODE                             = 0x04; // RW
-  public final static int PID_DEVICE_MODE                           = 0x05; // R
-  public final static int PID_FIRMWARE_M4_VERSION                   = 0x06; // R
-  public final static int PID_FIRMWARE_AS7000_VERSION               = 0x08; // R
-  public final static int PID_HW_VERSION                            = 0x09; // R
-  public final static int PID_FIRMWARE_BLE_VERSION                  = 0x0B; // R
-  public final static int PID_UNIQUE_DEVICE_ID                      = 0x12; // R
-  public final static int PID_STORAGE_TIME                          = 0x15; // RW
-  public final static int PID_NO_AVERAGE_PER_SAMPLE_AS7000          = 0x16; // RW
-  public final static int PID_GSR_ON                                = 0x1D; // RW
-  public final static int PID_ADVERTISING_NAME                      = 0x1E; // RW
-  public final static int PID_DTM_MODE                              = 0x1F; // W
-  public final static int PID_DISABLE_LOW_BAT_NOTIFICATION          = 0x20; // RW
-  public final static int PID_ENERGY_SUM_HOURS                      = 0x22; // R
-  public final static int PID_STEPS_SUM_HOURS                       = 0x23; // R
-  public final static int PID_SWITCH_DEVICE_OFF                     = 0x2A; // W
-  public final static int PID_TX_POWER                              = 0x2B; // RW
-  public final static int PID_SET_FACTORY_DEFAULT                   = 0x2C; // W
-  public final static int PID_DISCONNECT_BLE_CONN                  = 0x2D; // W
-  public final static int PID_SELF_TEST_RESULT                      = 0x2E; // R
-  public final static int PID_CLEAR_WHITE_LIST                      = 0x30; // W
-  public final static int PID_BOOTLOADER_VERSIOM                    = 0x31; // R
-  public final static int PID_BL_KEY_META_DATA                      = 0x32; // R
-  public final static int PID_DISABLE_DOUBLE_TAP_NOTIFICATION       = 0x33; // RW
-
-  // GAP Request
-  public final static int PID_GAP_REQUEST_STATUS                    = 0x21; // R
-  public final static int PID_GAP_RECORD_REQUEST                    = 0x11; // W
-  public final static int PID_SET_LAST_COUNTER_VALUE                = 0x2F; // W
-
-  public final static int PID_LAST_ERROR_COUNTER_VALUE              = 0x0F; // R
-  public final static int PID_LAST_LOG_COUNTER_VALUE                = 0x10; // R
-  public final static int PID_LAST_VITAL_DATA_COUNTER_VALUE         = 0x0E; // R
-  public final static int PID_LAST_IPI_DATA_COUNTER_VALUE           = 0x27; // R
-  public final static int PID_LAST_RAW_COUNTER_VALUE                = 0x24; // R
-
-  public final static int PID_NUMBER_OF_ERROR_LOG_SETS_IN_STORAGE   = 0x1B; // R
-  public final static int PID_NUMBER_OF_LOG_SETS_IN_STORAGE         = 0x19; // R
-  public final static int PID_NUMBER_OF_VITAL_DATA_SETS_IN_STORAGE  = 0x17; // R
-  public final static int PID_NUMBER_OF_IPI_DATA_SETS_IN_STORAGE    = 0x28; // R
-  public final static int PID_NUMBER_OF_RAW_DATA_SETS_IN_STORAGE    = 0x25; // R
-
-  /**
-   * GAP request data types
-   */
-  public final static int GAP_TYPE_ERROR_LOG    = 0x00;
-  public final static int GAP_TYPE_EVENT_LOG    = 0x01;
-  public final static int GAP_TYPE_VITAL        = 0x02;
-  public final static int GAP_TYPE_IPI          = 0x03;
-  public final static int GAP_TYPE_VITAL_RAW    = 0x10;
-
-  /**
-   * GAP request maximum number of records per page, whole pages will be streamed if possible
-   */
-  public final static int GAP_MAX_PER_PAGE_ERROR_LOG    = 0x0C;
-  public final static int GAP_MAX_PER_PAGE_EVENT_LOG    = 0x09;
-  public final static int GAP_MAX_PER_PAGE_VITAL        = 0x09;
-  public final static int GAP_MAX_PER_PAGE_IPI          = 0x27;
-  public final static int GAP_MAX_PER_PAGE_VITAL_RAW    = 0x11;
-
-  /**
-   * GAP request miscellaneous
-   */
-  public final static int GAP_NUM_PAGES     = 10; // number of pages to get with one request
-  public final static int GAP_INTERVAL_MS   = 500; // try a new GAP request every x milliseconds
-  public final static int GAP_NUM_LOOKUP    = 0; // maximum number of pages to look into the past, if set to -1 will look as far as possible (more of a debug feature for now, not fully implemented)
+    /**
+     * Default Bluetooth connection timeout. If this timeout is reached, the callback
+     * VsmDeviceListener#onVsmDeviceConnectionError(VsmDevice, VsmConnectionState) is called.
+     *
+     * <p>
+     * The default timeout on Android is 30 seconds. Using the BLE library, the maximum timeout value
+     * is fixed to 25 seconds.
+     * When connecting the first time to a VSM device, the connection time can be up to 5 seconds because the pairing
+     * process can take time and it is based on some internal delays.
+     */
+    public final static int BLE_CONN_TIMEOUT_MS = 10000;
 
 
-  /**
-   * UTC set time interval
-   */
-  public final static int UTC_INTERVAL_MS   = 60000; // set the device UTC time every x milliseconds
+    /**
+     * Parameter IDs according to VSM Bluetooth Comms Spec
+     */
+    public final static int PID_INTERFACE_VERSION                     = 0x00; // R
+    public final static int PID_UTC                                   = 0x01; // RW
+    public final static int PID_ALGO_MODE                             = 0x04; // RW
+    public final static int PID_DEVICE_MODE                           = 0x05; // R
+    public final static int PID_FIRMWARE_M4_VERSION                   = 0x06; // R
+    public final static int PID_FIRMWARE_AS7000_VERSION               = 0x08; // R
+    public final static int PID_HW_VERSION                            = 0x09; // R
+    public final static int PID_FIRMWARE_BLE_VERSION                  = 0x0B; // R
+    public final static int PID_UNIQUE_DEVICE_ID                      = 0x12; // R
+    public final static int PID_STORAGE_TIME                          = 0x15; // RW
+    public final static int PID_NO_AVERAGE_PER_SAMPLE_AS7000          = 0x16; // RW
+    public final static int PID_GSR_ON                                = 0x1D; // RW
+    public final static int PID_ADVERTISING_NAME                      = 0x1E; // RW
+    public final static int PID_DTM_MODE                              = 0x1F; // W
+    public final static int PID_DISABLE_LOW_BAT_NOTIFICATION          = 0x20; // RW
+    public final static int PID_ENERGY_SUM_HOURS                      = 0x22; // R
+    public final static int PID_STEPS_SUM_HOURS                       = 0x23; // R
+    public final static int PID_SWITCH_DEVICE_OFF                     = 0x2A; // W
+    public final static int PID_TX_POWER                              = 0x2B; // RW
+    public final static int PID_SET_FACTORY_DEFAULT                   = 0x2C; // W
+    public final static int PID_DISCONNECT_BLE_CONN                  = 0x2D; // W
+    public final static int PID_SELF_TEST_RESULT                      = 0x2E; // R
+    public final static int PID_CLEAR_WHITE_LIST                      = 0x30; // W
+    public final static int PID_BOOTLOADER_VERSIOM                    = 0x31; // R
+    public final static int PID_BL_KEY_META_DATA                      = 0x32; // R
+    public final static int PID_DISABLE_DOUBLE_TAP_NOTIFICATION       = 0x33; // RW
+
+    // GAP Request
+    public final static int PID_GAP_REQUEST_STATUS                    = 0x21; // R
+    public final static int PID_GAP_RECORD_REQUEST                    = 0x11; // W
+    public final static int PID_SET_LAST_COUNTER_VALUE                = 0x2F; // W
+
+    public final static int PID_LAST_ERROR_COUNTER_VALUE              = 0x0F; // R
+    public final static int PID_LAST_LOG_COUNTER_VALUE                = 0x10; // R
+    public final static int PID_LAST_VITAL_DATA_COUNTER_VALUE         = 0x0E; // R
+    public final static int PID_LAST_IPI_DATA_COUNTER_VALUE           = 0x27; // R
+    public final static int PID_LAST_RAW_COUNTER_VALUE                = 0x24; // R
+
+    public final static int PID_NUMBER_OF_ERROR_LOG_SETS_IN_STORAGE   = 0x1B; // R
+    public final static int PID_NUMBER_OF_LOG_SETS_IN_STORAGE         = 0x19; // R
+    public final static int PID_NUMBER_OF_VITAL_DATA_SETS_IN_STORAGE  = 0x17; // R
+    public final static int PID_NUMBER_OF_IPI_DATA_SETS_IN_STORAGE    = 0x28; // R
+    public final static int PID_NUMBER_OF_RAW_DATA_SETS_IN_STORAGE    = 0x25; // R
+
+    /**
+     * GAP request data types
+     */
+    public final static int GAP_TYPE_ERROR_LOG    = 0x00;
+    public final static int GAP_TYPE_EVENT_LOG    = 0x01;
+    public final static int GAP_TYPE_VITAL        = 0x02;
+    public final static int GAP_TYPE_IPI          = 0x03;
+    public final static int GAP_TYPE_VITAL_RAW    = 0x10;
+
+    /**
+     * GAP request maximum number of records per page, whole pages will be streamed if possible
+     */
+    public final static int GAP_MAX_PER_PAGE_ERROR_LOG    = 0x0C;
+    public final static int GAP_MAX_PER_PAGE_EVENT_LOG    = 0x09;
+    public final static int GAP_MAX_PER_PAGE_VITAL        = 0x09;
+    public final static int GAP_MAX_PER_PAGE_IPI          = 0x27;
+    public final static int GAP_MAX_PER_PAGE_VITAL_RAW    = 0x11;
+
+    /**
+     * GAP request responses
+     */
+    public final static int GAP_RESPONSE_PARAMETER_STATUS_OK        = 0x00;
+    public final static int GAP_RESPONSE_PARAMETER_OUT_OF_RANGE     = 0x03;
+    public final static int GAP_RESPONSE_BUSY                       = 0x05;
+    public final static int GAP_RESPONSE_UNKNOWN_STORAGE            = 0x06;
+    public final static int GAP_RESPONSE_NO_DATA                    = 0x07;
+    public final static int GAP_RESPONSE_INTERNAL_ERROR             = 0x08;
+
+    /**
+     * GAP statuses
+     */
+    public final static int GAP_STATUS_RUNNING              = 0x00;
+    public final static int GAP_STATUS_SUCCESSFUL           = 0x01;
+    public final static int GAP_STATUS_ERROR_NO_MORE_DATA   = 0x02;
+    public final static int GAP_STATUS_ERROR_NO_PAGE        = 0x03;
+    public final static int GAP_STATUS_ERROR_OVERFLOW       = 0x04;
+    public final static int GAP_STATUS_ERROR_BLE            = 0x05;
+    public final static int GAP_STATUS_ERROR_NOMAIL         = 0x06;
+    public final static int GAP_STATUS_FOTA_RUNNING         = 0x07;
+
+    /**
+     * GAP request miscellaneous
+     */
+    public final static int GAP_MAX_PAGES     = 50; // max number of pages to get with one request
+    public final static int GAP_INTERVAL_MS   = 500; // try a new GAP request every x milliseconds
 
 
-  /**
-   * VSM algorithm modes
-   */
-  public final static int MOD_VITAL_MODE                = 0x00;
-  public final static int MOD_VITAL_CAPPED_MODE         = 0x01;
-  public final static int MOD_RAW_DATA_VITAL_MODE       = 0x04;
-  public final static int MOD_RAW_DATA_HR_ONLY_MODE     = 0x05;
-  public final static int MOD_SELF_TEST_MODE            = 0x06;
-  public final static int MOD_MIXED_VITAL_RAW           = 0x09;
-  public final static int MOD_VITAL_MODE_AUTO_DATA      = 0x0A;
-  public final static int MOD_GREEN_ONLY_MODE           = 0x0B;
-  public final static int MOD_RAW_DATA_FIX_CURRENT      = 0x0C;
-  public final static int MOD_SHORT_SELF_TEST_MODE      = 0x0D;
-  public final static int MOD_MIXED_VITAL_RAW_SILENT    = 0x0E;
+    /**
+     * UTC set time interval
+     */
+    public final static int UTC_INTERVAL_MS   = 60000; // set the device UTC time every x milliseconds
 
 
-  /**
-   * VSM device modes
-   */
-  public final static int MOD_IDLE            = 0x00;
-  public final static int MOD_MEASURE         = 0x01;
-  public final static int MOD_ONCHARGER       = 0x02;
+    /**
+     * VSM algorithm modes
+     */
+    public final static int MOD_VITAL_MODE                = 0x00;
+    public final static int MOD_VITAL_CAPPED_MODE         = 0x01;
+    public final static int MOD_RAW_DATA_VITAL_MODE       = 0x04;
+    public final static int MOD_RAW_DATA_HR_ONLY_MODE     = 0x05;
+    public final static int MOD_SELF_TEST_MODE            = 0x06;
+    public final static int MOD_MIXED_VITAL_RAW           = 0x09;
+    public final static int MOD_VITAL_MODE_AUTO_DATA      = 0x0A;
+    public final static int MOD_GREEN_ONLY_MODE           = 0x0B;
+    public final static int MOD_RAW_DATA_FIX_CURRENT      = 0x0C;
+    public final static int MOD_SHORT_SELF_TEST_MODE      = 0x0D;
+    public final static int MOD_MIXED_VITAL_RAW_SILENT    = 0x0E;
 
 
-  private VsmConstants() {
-    // Private
-  }
+    /**
+     * VSM device modes
+     */
+    public final static int MOD_IDLE            = 0x00;
+    public final static int MOD_MEASURE         = 0x01;
+    public final static int MOD_ONCHARGER       = 0x02;
+
+
+    private VsmConstants() {
+        // Private
+    }
 }

--- a/src/main/java/org/radarcns/biovotion/VsmConstants.java
+++ b/src/main/java/org/radarcns/biovotion/VsmConstants.java
@@ -79,7 +79,7 @@ public final class VsmConstants {
     public final static int PID_SWITCH_DEVICE_OFF                     = 0x2A; // W
     public final static int PID_TX_POWER                              = 0x2B; // RW
     public final static int PID_SET_FACTORY_DEFAULT                   = 0x2C; // W
-    public final static int PID_DISCONNECT_BLE_CONN                  = 0x2D; // W
+    public final static int PID_DISCONNECT_BLE_CONN                   = 0x2D; // W
     public final static int PID_SELF_TEST_RESULT                      = 0x2E; // R
     public final static int PID_CLEAR_WHITE_LIST                      = 0x30; // W
     public final static int PID_BOOTLOADER_VERSIOM                    = 0x31; // R
@@ -147,7 +147,7 @@ public final class VsmConstants {
      * GAP request miscellaneous
      */
     public final static int GAP_MAX_PAGES        = 50; // max number of pages to get with one request
-    public final static int GAP_MAX_LOOKBACK_MS  = 3600000; // max time to look back into past and get missing records
+    public final static int GAP_MAX_LOOKBACK_MS  = 0;//3600000; // max time to look back into past and get missing records (0: infinite)
     public final static int GAP_INTERVAL_MS      = 500; // try a new GAP request every x milliseconds
 
 

--- a/src/main/java/org/radarcns/biovotion/VsmConstants.java
+++ b/src/main/java/org/radarcns/biovotion/VsmConstants.java
@@ -33,8 +33,8 @@ public final class VsmConstants {
     /**
      * sharedPreferences keys for storage of GAP request info
      */
-    public static final String BIOVOTION_PREFS = "org.radarcns.biovotion";
-    public static final String GAP_LAST_INDEX = "org.radarcns.biovotion.gapLastIndex";
+    public static final String VSM_PREFS = "org.radarcns.biovotion";
+    public static final String VSM_PREFS_GAP_LAST_INDEX = "org.radarcns.biovotion.gapLastIndex";
 
     // Reverse raw data before sending to kafka, because GAP gets in reverse-chronological order
     public static final boolean VSM_REVERSE_RAW_DATA = false;
@@ -55,7 +55,7 @@ public final class VsmConstants {
     /**
      * VSM sensor sampling rates
      */
-    public final static float VSM_VS_SAMPLE_RATE = 1f; // vital sign data sample rate, in Hz
+    public final static float VSM_VENDOR_SAMPLE_RATE = 1f; // vital sign data sample rate, in Hz
     public final static float VSM_RAW_SAMPLE_RATE = 51.2f; // raw data sample rate, in Hz
 
 

--- a/src/main/java/org/radarcns/biovotion/VsmConstants.java
+++ b/src/main/java/org/radarcns/biovotion/VsmConstants.java
@@ -50,6 +50,13 @@ public final class VsmConstants {
 
 
     /**
+     * VSM sensor sampling rates
+     */
+    public final static float VSM_VS_SAMPLE_RATE = 1f; // vital sign data sample rate, in Hz
+    public final static float VSM_RAW_SAMPLE_RATE = 51.2f; // raw data sample rate, in Hz
+
+
+    /**
      * Parameter IDs according to VSM Bluetooth Comms Spec
      */
     public final static int PID_INTERFACE_VERSION                     = 0x00; // R
@@ -139,8 +146,9 @@ public final class VsmConstants {
     /**
      * GAP request miscellaneous
      */
-    public final static int GAP_MAX_PAGES     = 50; // max number of pages to get with one request
-    public final static int GAP_INTERVAL_MS   = 500; // try a new GAP request every x milliseconds
+    public final static int GAP_MAX_PAGES        = 50; // max number of pages to get with one request
+    public final static int GAP_MAX_LOOKBACK_MS  = 3600000; // max time to look back into past and get missing records
+    public final static int GAP_INTERVAL_MS      = 500; // try a new GAP request every x milliseconds
 
 
     /**

--- a/src/main/java/org/radarcns/biovotion/VsmConstants.java
+++ b/src/main/java/org/radarcns/biovotion/VsmConstants.java
@@ -51,7 +51,7 @@ public final class VsmConstants {
      */
     public final static int BLE_CONN_TIMEOUT_MS = 10000;
 
-    public final static int BLE_BLACKLIST_TIMEOUT_MS = 10000; // maximum time for device to remain in BLE connection blacklist
+    public final static int BLE_BLACKLIST_TIMEOUT_MS = 30000; // maximum time for device to remain in BLE connection blacklist
 
 
     /**
@@ -153,8 +153,8 @@ public final class VsmConstants {
      */
     public final static int GAP_MAX_PAGES        = 50; // max number of pages to get with one request
     public final static int GAP_MAX_LOOKBACK_MS  = 0;//3600000; // max time to look back into past and get missing records (0: infinite)
-    public final static int GAP_INTERVAL_MS      = 1000; // try a new GAP request every x milliseconds
-    public final static int GAP_MAX_REQUEST_MS   = 120000; // maximum time for GAP request until disconnect is forced
+    public final static int GAP_INTERVAL_MS      = 5000; // try a new GAP request every x milliseconds
+    public final static int GAP_MAX_REQUEST_MS   = 30000; // maximum time for GAP request until disconnect is forced
 
 
     /**

--- a/src/main/java/org/radarcns/biovotion/VsmConstants.java
+++ b/src/main/java/org/radarcns/biovotion/VsmConstants.java
@@ -51,6 +51,8 @@ public final class VsmConstants {
      */
     public final static int BLE_CONN_TIMEOUT_MS = 10000;
 
+    public final static int BLE_BLACKLIST_TIMEOUT_MS = 120000; // maximum time for device to remain in BLE connection blacklist
+
 
     /**
      * VSM sensor sampling rates

--- a/src/main/java/org/radarcns/biovotion/VsmConstants.java
+++ b/src/main/java/org/radarcns/biovotion/VsmConstants.java
@@ -151,7 +151,8 @@ public final class VsmConstants {
      */
     public final static int GAP_MAX_PAGES        = 50; // max number of pages to get with one request
     public final static int GAP_MAX_LOOKBACK_MS  = 0;//3600000; // max time to look back into past and get missing records (0: infinite)
-    public final static int GAP_INTERVAL_MS      = 500; // try a new GAP request every x milliseconds
+    public final static int GAP_INTERVAL_MS      = 1000; // try a new GAP request every x milliseconds
+    public final static int GAP_MAX_REQUEST_MS   = 120000; // maximum time for GAP request until disconnect is forced
 
 
     /**


### PR DESCRIPTION
Complete revamp of GAP requests (current and past raw data)
- restructured GAP requests into separate classes, for readability and better management
- GAP requests more robust
- will now get missing raw data since last connection
- implemented a device blacklist with timeout which prevents connecting to devices over and over

TODO:
- [x] address https://github.com/RADAR-CNS/radar-android-biovotion/pull/3#discussion_r147641100
- [x] test robustness with multiple devices and exchanging them
- [x] possibly remove raw data stacks which are used for making data chronological
- [x] new API version is needed for devices with newer firmware (some minor features broken)